### PR TITLE
Fix recording pause/resume on Android

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
@@ -36,6 +36,7 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
 
     Map<Integer, MediaRecorder> recorderPool = new HashMap<>();
     Map<Integer, Boolean> recorderAutoDestroy = new HashMap<>();
+    Map<Integer, Boolean> recorderPaused = new HashMap<>();
 
     private ReactApplicationContext context;
 
@@ -147,6 +148,7 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
             recorder.release();
             this.recorderPool.remove(recorderId);
             this.recorderAutoDestroy.remove(recorderId);
+            this.recorderPaused.remove(recorderId);
 
             WritableMap data = new WritableNativeMap();
             data.putString("message", "Destroyed recorder");
@@ -230,6 +232,7 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
         }
 
         this.recorderAutoDestroy.put(recorderId, autoDestroy);
+        this.recorderPaused.put(recorderId, false);
 
         try {
             recorder.prepare();
@@ -249,7 +252,12 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
         }
 
         try {
-            recorder.start();
+            if (this.recorderPaused.get(recorderId)) {
+                recorder.resume();
+                this.recorderPaused.put(recorderId, false);
+            } else {
+                recorder.start();
+            }
 
             callback.invoke();
         } catch (Exception e) {
@@ -297,6 +305,7 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
 
         try {
             recorder.pause();
+            this.recorderPaused.put(recorderId, true);
             callback.invoke();
         } catch (Exception e) {
             callback.invoke(errObj("stopfail", e.toString()));

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
@@ -297,10 +297,6 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
 
         try {
             recorder.pause();
-            if (this.recorderAutoDestroy.get(recorderId)) {
-                Log.d(LOG_TAG, "Autodestroying recorder...");
-                destroy(recorderId);
-            }
             callback.invoke();
         } catch (Exception e) {
             callback.invoke(errObj("stopfail", e.toString()));


### PR DESCRIPTION
Currently the recorder is destroyed (unless `autoDestroy` is disabled) when `pause()` is called, and even if `autoDestroy` is disabled the recording cannot be resumed because the `MediaRecorder` requires that `resume()` is called instead of `start()`.

This PR fixes both issues.