### PR TITLE
playerId setted as paramiter to controll specific audio player on screen

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -25,7 +25,7 @@ class Player extends EventEmitter {
     this._path = path;
     this._options = options;
 
-    this._playerId = playerId++;
+    this._playerId = options.id ? options.id : playerId++;
     this._reset();
 
     const appEventEmitter = Platform.OS === 'ios' ? NativeAppEventEmitter : DeviceEventEmitter;


### PR DESCRIPTION
As this feature has helped me to controll more than one audio instance on screen, I'd like to share it with the community because someone should have had passed by the same problem.