### PR TITLE
fix SOURCES.md Bundle media with application example

### DIFF
--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -20,7 +20,7 @@ follow these steps:
     compatibility.
 
 Your file will now be built into your app's installation file, and you can play
-back the file using `new Player.play('example.mp3');`
+back the file using `new Player('example.mp3').play();`
 
 Stream media over network
 -------------------------


### PR DESCRIPTION
The example in SOURCES.md will not work.
Under Bundle media with application,

> ...using `new Player.play('example.mp3');`

should be:

> ...using `new Player('example.mp3').play();`