### PR TITLE
Follow SDK/lib versioning conventions, fix min API level error

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: "com.android.library"
 
+def projectVar(name, fallback) {
+    return project.findProperty(name) ?: fallback
+}
+
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.1"
+    compileSdkVersion projectVar('compileSdkVersion', 27)
+    buildToolsVersion projectVar('buildToolsVersion', '27.0.3')
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 23
+        targetSdkVersion projectVar('targetSdkVersion', 27)
         versionCode 1
         versionName "1.0"
     }
@@ -19,7 +23,9 @@ android {
 }
 
 dependencies {
+    def supportLibVersion = projectVar('supportLibVersion', '27.1.1')
+
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -6,6 +6,7 @@ import android.media.MediaPlayer;
 import android.media.PlaybackParams;
 import android.media.AudioAttributes;
 import android.media.AudioAttributes.Builder;
+import android.os.Build;
 import android.os.Environment;
 import android.os.PowerManager;
 import android.support.annotation.Nullable;
@@ -328,7 +329,8 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
             this.looping = options.getBoolean("looping");
         }
 
-        if (options.hasKey("speed") || options.hasKey("pitch")) {
+        // `PlaybackParams` was only added in API 23
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && (options.hasKey("speed") || options.hasKey("pitch"))) {
             PlaybackParams params = new PlaybackParams();
 
             if (options.hasKey("speed") && !options.isNull("speed")) {


### PR DESCRIPTION
Prevents headaches from version mismatches, and a potential API versioning error (`PlaybackParams` is only available on API 23 and up but min is 19).