### PR TITLE
Fix prepare never completing on iOS for sounds with a length less than 10s

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -137,7 +137,6 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     
     // If successful, check options and add to player pool
     if (player) {
-        
         NSNumber *autoDestroy = [options objectForKey:@"autoDestroy"];
         if (autoDestroy) {
             player.autoDestroy = [autoDestroy boolValue];
@@ -171,12 +170,13 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     if (version >= 10.0) {
         player.automaticallyWaitsToMinimizeStalling = false;
     }
-    Float64 durationSeconds = 0;
-    while (durationSeconds < 10){
+    Float64 loadedDurationSeconds = 0;
+    Float64 totalDurationSeconds = CMTimeGetSeconds(player.currentItem.duration);
+    while (loadedDurationSeconds < 10 && loadedDurationSeconds < totalDurationSeconds){
         NSValue *val = player.currentItem.loadedTimeRanges.firstObject;
         CMTimeRange timeRange;
         [val getValue:&timeRange];
-        durationSeconds = CMTimeGetSeconds(timeRange.duration);
+        loadedDurationSeconds = CMTimeGetSeconds(timeRange.duration);
         [NSThread sleepForTimeInterval:0.01f];
     }
     


### PR DESCRIPTION
PR #74 added code to `AudioPlayer.m` that waits for audio clips to preload at least 10s of audio data before calling the callback.

This causes audio clips with a length of less than 10s to never finish preparing. This PR fixes that.