### PR TITLE
Guard against exceptions that can appear on Android in onHostPause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed some incorrect examples in the documentation
 - Android: Guard against possible exceptions while parsing stack trace
+- Android: Guard against exceptions that can appear in onHostPause
 - Android: Fix build error related to defining `android:minSdkVersion` in the library's AndroidManifest
 - Android: Fix crash on devices running API level 22 or earlier
 - iOS: Fix `Player.pause()` not setting `PAUSED` state


### PR DESCRIPTION
I've received reports of crashes happening on Android on an app that I'm currently developing that uses react-native-audio-toolkit. My Google Play Developer Console is reporting these 2 crashes so far:

```
Caused by: java.lang.IllegalStateException: 
  at android.media.MediaPlayer.getAudioSessionId (Native Method)
  at com.futurice.rctaudiotoolkit.AudioPlayerModule.getInfo (AudioPlayerModule.java:222)
  at com.futurice.rctaudiotoolkit.AudioPlayerModule.onHostPause (AudioPlayerModule.java:71)
  at com.facebook.react.bridge.ReactContext.onHostPause (ReactContext.java:212)
  at com.facebook.react.ReactInstanceManager.moveToBeforeResumeLifecycleState (ReactInstanceManager.java:673)
  at com.facebook.react.ReactInstanceManager.onHostPause (ReactInstanceManager.java:497)
  at com.facebook.react.ReactInstanceManager.onHostPause (ReactInstanceManager.java:516)
  at com.facebook.react.ReactActivityDelegate.onPause (ReactActivityDelegate.java:99)
  at com.facebook.react.ReactActivity.onPause (ReactActivity.java:58)
  at android.app.Activity.performPause (Activity.java:7605)
  at android.app.Instrumentation.callActivityOnPause (Instrumentation.java:1465)
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:4224)
```

```
Caused by: java.util.ConcurrentModificationException: 
  at java.util.HashMap$HashIterator.nextNode (HashMap.java:1441)
  at java.util.HashMap$EntryIterator.next (HashMap.java:1475)
  at java.util.HashMap$EntryIterator.next (HashMap.java:1473)
  at com.futurice.rctaudiotoolkit.AudioPlayerModule.onHostPause (AudioPlayerModule.java:64)
  at com.facebook.react.bridge.ReactContext.onHostPause (ReactContext.java:212)
  at com.facebook.react.ReactInstanceManager.moveToBeforeResumeLifecycleState (ReactInstanceManager.java:673)
  at com.facebook.react.ReactInstanceManager.onHostPause (ReactInstanceManager.java:497)
  at com.facebook.react.ReactInstanceManager.onHostPause (ReactInstanceManager.java:516)
  at com.facebook.react.ReactActivityDelegate.onPause (ReactActivityDelegate.java:99)
  at com.facebook.react.ReactActivity.onPause (ReactActivity.java:58)
  at android.app.Activity.performPause (Activity.java:7605)
  at android.app.Instrumentation.callActivityOnPause (Instrumentation.java:1465)
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:4224)
```

The changes in this PR attempt to guard against these specific crashes.