### PR TITLE
Guard against possible exceptions while parsing stack trace

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -103,11 +103,14 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
     private WritableMap errObj(final String code, final String message, final boolean enableLog) {
         WritableMap err = Arguments.createMap();
 
-        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         String stackTraceString = "";
-
-        for (StackTraceElement e : stackTrace) {
-            stackTraceString += e.toString() + "\n";
+        try {
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            for (StackTraceElement e : stackTrace) {
+                stackTraceString += (e != null ? e.toString() : "null") + "\n";
+            }
+        } catch (Exception e) {
+            stackTraceString = "Exception occurred while parsing stack trace";
         }
 
         err.putString("err", code);

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
@@ -62,11 +62,14 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
     private WritableMap errObj(final String code, final String message) {
         WritableMap err = Arguments.createMap();
 
-        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         String stackTraceString = "";
-
-        for (StackTraceElement e : stackTrace) {
-            stackTraceString += e.toString() + "\n";
+        try {
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            for (StackTraceElement e : stackTrace) {
+                stackTraceString += (e != null ? e.toString() : "null") + "\n";
+            }
+        } catch (Exception e) {
+            stackTraceString = "Exception occurred while parsing stack trace";
         }
 
         err.putString("err", code);


### PR DESCRIPTION
According to the [docs](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html), `Thread.currentThread().getStackTrace()` has the possibility to throw a `SecurityException`. This PR adds a guard against that.