### PR TITLE
BREAKING CHANGE: Remove permissions from library and instead require users to add them

### DIFF
--- a/ExampleApp/android/app/src/main/AndroidManifest.xml
+++ b/ExampleApp/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
   package="com.reactnativeaudiotoolkit.exampleapp">
 
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   <application
     android:name=".MainApplication"

--- a/android/lib/src/main/AndroidManifest.xml
+++ b/android/lib/src/main/AndroidManifest.xml
@@ -3,11 +3,5 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
-    <uses-sdk android:targetSdkVersion="24" />
+    <uses-sdk android:targetSdkVersion="28" />
 </manifest> 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -57,23 +57,38 @@ an actual Android/iOS device:
     }
     ```
 
-4. (optional) If you wish to record audio, add the following permissions to
-    `android/app/src/main/AndroidManifest.xml`
+4. (optional) Doing specific tasks with this library requires adding permissions to your
+    Android manifest file, which can be found at `android/app/src/main/AndroidManifest.xml`
 
     ```xml
     <manifest ...>
 
+        <!-- If you want to play audio from a SD card (i.e. external storage),
+             you need to add this permission -->
+        <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+        <!-- If you want to play audio from a URL, you need to add these permissions -->
+        <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+        <!-- If you want to record audio, you need to add this permission -->
         <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+        <!-- If you want to record audio to a SD card (i.e. external storage),
+             you need to add this permission -->
         <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         ...
 
     </manifest>
     ```
 
-    This is to get permissions for recording audio and writing to external storage.
-
-    TODO: Android 6.0 permissions model once supported by React Native:
-    https://facebook.github.io/react-native/docs/known-issues.html#android-m-permissions
+    For versions of Android earlier than Android 6.0, the user is asked to agree to permission
+    when installing the app. However, on Android 6.0+ the app developer is responsible for
+    asking for permissions before they are required.
+    
+    For an example of this in action, check out the code in the ExampleApp at
+    `ExampleApp/src/App.js` or check out the documentation for
+    [PermissionsAndroid](https://facebook.github.io/react-native/docs/permissionsandroid).
 
 ### iOS setup
 


### PR DESCRIPTION
A number of the permissions that were included in `android/lib/src/main/AndroidManifest.xml` are considered by Google to be "[Dangerous Permissions](https://developer.android.com/guide/topics/permissions/overview#dangerous_permissions)" and recommends that apps shouldn't include them unless they absolutely need them. But by including them directly in this library's permissions, any app that uses this library automatically adds these permissions which is not ideal.

This PR removes these permissions from the library and improves the documentation around including and using them if the library user needs them.