### PR TITLE
Add aac-low

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioRecorderModule.java
@@ -106,8 +106,9 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
 
     private int encoderFromName(String name) {
         switch (name) {
-            case "aac":
+            case "aac-lc":
                 return MediaRecorder.AudioEncoder.AAC;
+            case "aac":
             case "mp4":
                 return MediaRecorder.AudioEncoder.HE_AAC;
             case "webm":


### PR DESCRIPTION
This fix issue https://github.com/react-native-community/react-native-audio-toolkit/issues/149

# Summary

Voice-Recording of some Devices (Samsung / Huawei) are not playable on Browser (<video-tag> of HTML5) or on IOS 12.2 devices.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
