### PR TITLE
Update the plist microphone access key in SETUP.md

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -111,8 +111,9 @@ React Native 0.59 and earlier:
     `libReactNativeAudioToolkit.a` from under Workspace.
     
 4. Add a usage description to **Info.plist**.
-    ```<key>Privacy - Microphone Usage Description</key>
-       <string>This app requires access to your microphone</string>
+    ```
+      <key>NSMicrophoneUsageDescription</key>
+	  <string>This app requires access to your microphone</string>
     ```
 
 React Native 0.60 and later

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -113,7 +113,7 @@ React Native 0.59 and earlier:
 4. Add a usage description to **Info.plist**.
     ```
       <key>NSMicrophoneUsageDescription</key>
-	  <string>This app requires access to your microphone</string>
+      <string>This app requires access to your microphone</string>
     ```
 
 React Native 0.60 and later


### PR DESCRIPTION
# Summary

Small update to the setup file. `Privacy - Microphone Usage Description` is what it shows in the Xcode UI, but `NSMicrophoneUsageDescription` is what is in the plist.
