### PR TITLE
Feature/mix with others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+- Add Player option mixWithOthers
 
 ## [2.0.2] - 2019-07-09
 ### Added

--- a/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
@@ -47,6 +47,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
     private ReactApplicationContext context;
     private AudioManager mAudioManager;
     private Integer lastPlayerId;
+    boolean mixWithOthers = false;
 
     public AudioPlayerModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -302,6 +303,13 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
             continueInBackground = options.getBoolean("continuesToPlayInBackground");
         }
 
+        // Don't mix audio with others by default
+        this.mixWithOthers = false;
+
+        if (options.hasKey("mixWithOthers")) {
+            this.mixWithOthers = options.getBoolean("mixWithOthers");
+        }
+
         this.playerAutoDestroy.put(playerId, autoDestroy);
         this.playerContinueInBackground.put(playerId, continueInBackground);
 
@@ -383,7 +391,9 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         }
 
         try {
-            this.mAudioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+            if (!this.mixWithOthers) {
+                this.mAudioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+            }
             player.start();
 
             callback.invoke(null, getInfo(player));

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,11 @@ Media methods
       // (Android only) Should playback continue if app is sent to background?
       // iOS will always pause in this case.
       continuesToPlayInBackground : boolean (default: False)
+
+      // Boolean to determine whether other audio sources on the device will mix
+      // with sounds being played back by this module. If this is not set, playback
+      // of audio will stop other sources
+      mixWithOthers : boolean (default: False)
     }
     ```
 

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -123,8 +123,9 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
                                                object:item];
     
     // Set audio session
+    NSNumber *mixWithOthers = [options objectForKey:@"mixWithOthers"];
     NSError *error = nil;
-    [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback error: &error];
+    [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback withOptions: mixWithOthers ? AVAudioSessionCategoryOptionMixWithOthers : nil error: &error];
     if (error) {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"
                                          withMessage:@"Failed to set audio session category."];

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -125,7 +125,7 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     // Set audio session
     NSNumber *mixWithOthers = [options objectForKey:@"mixWithOthers"];
     NSError *error = nil;
-    [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback withOptions: mixWithOthers ? AVAudioSessionCategoryOptionMixWithOthers : nil error: &error];
+    [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback withOptions: mixWithOthers ? AVAudioSessionCategoryOptionMixWithOthers : 0 error: &error];
     if (error) {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"
                                          withMessage:@"Failed to set audio session category."];

--- a/src/Player.js
+++ b/src/Player.js
@@ -17,6 +17,7 @@ let playerId = 0;
 const defaultPlayerOptions = {
   autoDestroy: true,
   continuesToPlayInBackground: false,
+  mixWithOthers: false,
 };
 
 /**
@@ -37,6 +38,8 @@ class Player extends EventEmitter {
         options.autoDestroy = defaultPlayerOptions.autoDestroy;
       if (options.continuesToPlayInBackground == null)
         options.continuesToPlayInBackground = defaultPlayerOptions.continuesToPlayInBackground;
+      if (options.mixWithOthers == null)
+        options.mixWithOthers = defaultPlayerOptions.mixWithOthers;
 
       this._options = options;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,7 +44,14 @@ interface PlayerOptions {
      * iOS will always pause in this case.
      * (Default: false)
      */
+
     continuesToPlayInBackground?: boolean;
+    /**
+     * Boolean to determine whether other audio sources on the device will mix
+     * with sounds being played back by this module.
+     * (Default: false)
+     */
+    mixWithOthers?: boolean;
 }
 
 /**


### PR DESCRIPTION
# Summary

Needed to alter this module to allow playback of sound without interfering with other audio sources already playing on the device.

Adds configuration option "mixWithOthers" for both Android and iOS.

## Test Plan

Construct Player with option mixWithOthers set to true. Play audio from another app (i.e. Spotify) and then run your app, play a sound and it should not pause Spotify.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
