### PR TITLE
iOS Audio Playback Category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+- Add ability to override iOS audio session category
 
 ## [2.0.2] - 2019-07-09
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,10 @@ Media methods
       // (Android only) Should playback continue if app is sent to background?
       // iOS will always pause in this case.
       continuesToPlayInBackground : boolean (default: False)
+
+      // (iOS only) Define the audio session category
+      // Options: Playback, Ambient and SoloAmbient
+      category : PlaybackCategory (default: PlaybackCategory.Playback)
     }
     ```
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import Player from './src/Player';
+import Player, { PlaybackCategories } from './src/Player';
 import Recorder from './src/Recorder';
 import MediaStates from './src/MediaStates';
 
-export { Player, Recorder, MediaStates };
+export { Player, Recorder, MediaStates, PlaybackCategories };

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -124,7 +124,7 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     
     // Set audio session
     NSNumber *category = [options objectForKey:@"category"];
-    NSString avAudioSessionCategory;
+    NSString *avAudioSessionCategory;
     switch ([category intValue]) {
         case 1:
         default:

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -123,8 +123,22 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
                                                object:item];
     
     // Set audio session
+    NSNumber *category = [options objectForKey:@"category"];
+    NSString avAudioSessionCategory;
+    switch ([category intValue]) {
+        case 1:
+        default:
+            avAudioSessionCategory = AVAudioSessionCategoryPlayback;
+            break;
+        case 2:
+            avAudioSessionCategory = AVAudioSessionCategoryAmbient;
+            break;
+        case 3:
+            avAudioSessionCategory = AVAudioSessionCategorySoloAmbient;
+            break;
+    }
     NSError *error = nil;
-    [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback error: &error];
+    [[AVAudioSession sharedInstance] setCategory: avAudioSessionCategory error: &error];
     if (error) {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"
                                          withMessage:@"Failed to set audio session category."];

--- a/src/Player.js
+++ b/src/Player.js
@@ -14,9 +14,16 @@ const RCTAudioPlayer = NativeModules.AudioPlayer;
 
 let playerId = 0;
 
+export const PlaybackCategories = {
+  Playback: 1,
+  Ambient: 2,
+  SoloAmbient: 3,
+}
+
 const defaultPlayerOptions = {
   autoDestroy: true,
   continuesToPlayInBackground: false,
+  category: PlaybackCategories.Playback,
 };
 
 /**
@@ -37,6 +44,8 @@ class Player extends EventEmitter {
         options.autoDestroy = defaultPlayerOptions.autoDestroy;
       if (options.continuesToPlayInBackground == null)
         options.continuesToPlayInBackground = defaultPlayerOptions.continuesToPlayInBackground;
+      if (options.category == null)
+        options.category = defaultPlayerOptions.category;
 
       this._options = options;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,6 +14,12 @@ declare enum MediaStates {
     PAUSED = 5
 }
 
+declare enum PlaybackCategories {
+    Playback = 1,
+    Ambient = 2,
+    SoloAmbient = 3,
+}
+
 interface BaseError<T> {
     err: "invalidpath" | "preparefail" | "startfail" | "notfound" | "stopfail" | T;
     message: string;
@@ -45,6 +51,12 @@ interface PlayerOptions {
      * (Default: false)
      */
     continuesToPlayInBackground?: boolean;
+
+    /**
+     * (iOS only) Define the audio session category
+     * (Default: Playback)
+     */
+    category?: PlaybackCategories;
 }
 
 /**


### PR DESCRIPTION
# Summary

Allow configuring iOS audio session category rather than being forced to use AVAudioSessionCategoryPlayback.

## Test Plan

Put phone on silent, set new playback option category to PlaybackCategories.Ambient and sounds will no longer play.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
