### PR TITLE
Added OPUS audio format support, for both iOS and Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioRecorderModule.java
+++ b/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioRecorderModule.java
@@ -93,6 +93,8 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
                 return MediaRecorder.OutputFormat.WEBM;
             case "amr":
                 return MediaRecorder.OutputFormat.AMR_WB;
+            case "opus":
+                return MediaRecorder.OutputFormat.OPUS;
             default:
                 Log.e(LOG_TAG, "Format with name " + name + " not found.");
                 return MediaRecorder.OutputFormat.DEFAULT;
@@ -115,6 +117,8 @@ public class AudioRecorderModule extends ReactContextBaseJavaModule implements
                 return MediaRecorder.AudioEncoder.VORBIS;
             case "amr":
                 return MediaRecorder.AudioEncoder.AMR_WB;
+            case "opus":
+                return MediaRecorder.AudioEncoder.OPUS;
             default:
                 Log.e(LOG_TAG, "Encoder with name " + name + " not found.");
                 return MediaRecorder.AudioEncoder.DEFAULT;

--- a/docs/API.md
+++ b/docs/API.md
@@ -199,13 +199,13 @@ Player.isPrepared   true if player is prepared
       sampleRate : Number (default: 44100)
 
       // Override format. Possible values:
-      // Cross-platform:  'mp4', 'aac'
+      // Cross-platform:  'mp4', 'aac', 'opus'
       // Android only:    'ogg', 'webm', 'amr'
       format : String (default: based on filename extension)
 
       // Override encoder. Android only.
       // Possible values:
-      // 'aac', 'mp4', 'webm', 'ogg', 'amr'
+      // 'aac', 'mp4', 'webm', 'ogg', 'amr', 'opus'
       encoder : String (default: based on filename extension)
 
       // Quality of the recording, iOS only.

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/Helpers.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/Helpers.m
@@ -45,6 +45,9 @@
         if ([formatString isEqualToString:@"ac3"]) {
             format = [NSNumber numberWithInt:kAudioFormatMPEG4AAC];
         }
+        else if ([formatString isEqualToString:@"opus"]) {
+            format = [NSNumber numberWithInt:kAudioFormatOpus];
+        }
     }
     
     

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -211,7 +211,7 @@ interface RecorderOptions {
 
     /**
      * Override format. Possible values:
-     *   - Cross-platform:  'mp4', 'aac'
+     *   - Cross-platform:  'mp4', 'aac', 'opus'
      *   - Android only:    'ogg', 'webm', 'amr'
      * 
      * (Default: based on filename extension)
@@ -221,7 +221,7 @@ interface RecorderOptions {
     /**
      * Override encoder. Android only.
      * 
-     * Possible values: 'aac', 'mp4', 'webm', 'ogg', 'amr'
+     * Possible values: 'aac', 'mp4', 'webm', 'ogg', 'amr', 'opus'
      * 
      * (Default: based on filename extension)
      */


### PR DESCRIPTION
# Added OPUS audio format support, for both iOS and Android
<!--
Added a new file ext format: 'opus', for both iOS and Android. These are already supported on both platforms, so here I just added yet another switch case.
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
