### PR TITLE
Fix ios infinite loop when timerange does not exist

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -195,8 +195,22 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     }
 
     //make sure loadedTimeRanges is not null
-    while (player.currentItem.loadedTimeRanges.firstObject == nil){
-        [NSThread sleepForTimeInterval:0.01f];
+    while (player.currentItem.loadedTimeRanges.firstObject == nil) {
+        if (player.currentItem.status == AVPlayerItemStatusReadyToPlay) {
+            /* If the loadedTimeRanges.firstObject is nil and status is AVPlayerItemStatusReadyToPlay.
+               The player should have loadedTimeRanges. So something is not right with the file */
+            NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"
+                                             withMessage:@"timerange error"];
+            
+            if (player.autoDestroy) {
+                [self destroyPlayerWithId:playerId];
+            }
+            
+            callback(@[dict]);
+            return;
+        } else {
+            [NSThread sleepForTimeInterval:0.01f];
+        }
     }
     
     //wait until 10 seconds are buffered then play


### PR DESCRIPTION
# Summary

When I loaded a .m3u8 file which was 0 seconds.
The AudioPlayer.m went into an infinite loop.
It was checking for timeRanges which was never there.
This way we couldn't destroy the audio player. 

If the loadedTimeRanges.firstObject is nil and status is AVPlayerItemStatusReadyToPlay. The player should have loadedTimeRanges. When this is not the case we should return with error.
Otherwise we stay in the infinite loop.

## Test Plan

### What's required for testing (prerequisites)?
A .m3u8 file which is has 0 seconds.
Not sure how long this url will be valid. 

https://content.mediadistillery.tv/api/3/playout/097506e997b9445b38cf86961affd195a864522d25a536ed650dbbb4d93b89c5879e756c211239a5c04d72546869732069792061207784.m3u8?protocol=https&cursor=0

### What are the steps to reproduce (after prerequisites)?

Load the provided url.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I mentioned this change in `CHANGELOG.md`
