### PR TITLE
Fixes iOS9 crash when setting automaticallyWaitsToMinimzeStalling

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -219,7 +219,9 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     
     // Callback when ready / failed
     if (player.currentItem.status == AVPlayerStatusReadyToPlay) {
-        player.automaticallyWaitsToMinimizeStalling = false;
+        if (version >= 10.0) {
+            player.automaticallyWaitsToMinimizeStalling = false;
+        }
         callback(@[[NSNull null]]);
     } else {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"


### PR DESCRIPTION
### Where

* Related PRs: https://github.com/lingokids/app/pull/5391

### What

There is an unchecked setting of the AVPlayer property `automaticallyWaitsToMinimizeStalling` that is only available from iOS10 onwards. This causes a crash on iOS9:

![Screenshot 2020-06-02 at 10 44 29](https://user-images.githubusercontent.com/1830021/83499715-0ef68580-a4be-11ea-9a25-0f1bb9c998b4.png)

It is kind of weird, as the version check is being performed in other places where this property is set, but not here.

### How

I just added a version check for that specific line.