### PR TITLE
base64 data url support

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
@@ -251,8 +251,6 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         destroy(playerId);
         this.lastPlayerId = playerId;
 
-        Uri uri = uriFromPath(path);
-
         //MediaPlayer player = MediaPlayer.create(this.context, uri, null, attributes);
         MediaPlayer player = new MediaPlayer();
 
@@ -264,13 +262,23 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
 
         player.setAudioAttributes(attributes);
         */
-
-        try {
-            Log.d(LOG_TAG, uri.getPath());
-            player.setDataSource(this.context, uri);
-        } catch (IOException e) {
-            callback.invoke(errObj("invalidpath", e.toString()));
-            return;
+        if(path.startsWith("data:audio/")) {
+             try {
+                 player.setDataSource(path);
+             }
+             catch (IOException e) {
+                callback.invoke(errObj("invalid base64 data url", e.toString()));
+                return;
+            }
+        } else {
+            try {
+                Uri uri = uriFromPath(path);
+                Log.d(LOG_TAG, uri.getPath());
+                player.setDataSource(this.context, uri);
+            } catch (IOException e) {
+                callback.invoke(errObj("invalidpath", e.toString()));
+                return;
+            }
         }
 
         player.setOnErrorListener(this);

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -16,7 +16,6 @@
 #import "ReactPlayerItem.h"
 #import <AVFoundation/AVPlayer.h>
 #import <AVFoundation/AVPlayerItem.h>
-#import <AVFoundation/AVAsset.h>
 
 
 @interface AudioPlayer ()
@@ -102,18 +101,31 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
         callback(@[dict]);
         return;
     }
-        
-    // Try to find the correct file
-    NSURL *url = [self findUrlForPath:path];
-    if (!url) {
-        NSDictionary* dict = [Helpers errObjWithCode:@"invalidpath" withMessage:@"No file found at path"];
+    ReactPlayerItem *item;
+    if ([path hasPrefix:@"data:audio/"]) {
+        // inline data
+        NSData *data = [Helpers decodeBase64DataUrl:path];
+        if (!data) {
+            NSDictionary* dict = [Helpers errObjWithCode:@"invalidpath" withMessage:@"invalid data:audio URL"];
+            callback(@[dict]);
+            return;
+        }
+        item = (ReactPlayerItem *)[ReactPlayerItem playerItemWithData: data];
+     } else {
+        // Try to find the correct file
+        NSURL *url = [self findUrlForPath:path];
+        if (!url) {
+            NSDictionary* dict = [Helpers errObjWithCode:@"invalidpath" withMessage:@"No file found at path"];
+            callback(@[dict]);
+            return;
+        }
+        item = (ReactPlayerItem *)[ReactPlayerItem playerItemWithURL: url];
+    }
+    if (!item) {
+        NSDictionary* dict = [Helpers errObjWithCode:@"preparefail" withMessage:@"error initializing player item"];
         callback(@[dict]);
         return;
     }
-    
-    // Load asset from the url
-    AVURLAsset *asset = [AVURLAsset assetWithURL: url];
-    ReactPlayerItem *item = (ReactPlayerItem *)[ReactPlayerItem playerItemWithAsset: asset];
     item.reactPlayerId = playerId;
     
     // Add notification to know when file has stopped playing

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/Helpers.h
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/Helpers.h
@@ -17,4 +17,6 @@
 
 +(NSDictionary *)recorderSettingsFromOptions:(NSDictionary *)options;
 
++(NSData *)decodeBase64DataUrl:(NSString*)url;
+
 @end

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/Helpers.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/Helpers.m
@@ -77,4 +77,21 @@
     return recordSettings;
 }
 
++(NSData *)decodeBase64DataUrl:(NSString*)url {
+    NSRange b64r = [url rangeOfString:@";base64,"];
+    if(b64r.location == NSNotFound) {
+        NSLog(@"decodeBase64DataUrl - base64 not found in data: url");
+        return nil;
+    }
+    NSInteger idx = b64r.location + @";base64,".length;
+    NSString *b64string = [url substringFromIndex:idx];
+    NSData *b64decoded = [[NSData alloc] initWithBase64EncodedString:b64string options:NSASCIIStringEncoding];
+    if(b64decoded == nil) {
+        NSLog(@"decodeBase64DataUrl - error decoding base64 data");
+        return nil;
+    }
+    
+    return b64decoded;
+}
+
 @end

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayerItem.h
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayerItem.h
@@ -10,7 +10,9 @@
 
 #import <AVFoundation/AVFoundation.h>
 @class ReactPlayer;
-@interface ReactPlayerItem : AVPlayerItem
+@interface ReactPlayerItem : AVPlayerItem <AVAssetResourceLoaderDelegate>
+
++ (instancetype)playerItemWithData:(NSData *)data;
 
 @property (nonatomic, strong) NSNumber *reactPlayerId;
 

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayerItem.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayerItem.m
@@ -10,14 +10,95 @@
 
 #import "ReactPlayerItem.h"
 
-@implementation ReactPlayerItem
+@implementation ReactPlayerItem {
+    NSData *_data;
+}
 
 - (void)dealloc {
     self.reactPlayerId = nil;
+    _data = nil;
 }
 
-+ (instancetype)playerItemWithAsset:(AVAsset *)asset {
++ (instancetype)playerItemWithURL:(NSURL *)url {
+    AVURLAsset *asset = [AVURLAsset assetWithURL: url];
     return [[self alloc] initWithAsset:asset];
 }
+
++ (instancetype)playerItemWithData:(NSData *)data {
+    AVURLAsset *asset = [AVURLAsset assetWithURL:[NSURL URLWithString:@"data:"]];
+    ReactPlayerItem *rpi = [[self alloc] initWithAsset:asset];
+    dispatch_queue_t queue = dispatch_queue_create("assetQueue", nil);
+    [asset.resourceLoader setDelegate:rpi queue:queue];
+    rpi->_data = data;
+    return rpi;
+}
+
+#pragma mark - AVAssetResourceLoaderDelegate
+
+- (BOOL)resourceLoader:(AVAssetResourceLoader *)resourceLoader shouldWaitForRenewalOfRequestedResource:(AVAssetResourceRenewalRequest *)renewalRequest {
+  return [self loadingRequestHandling:renewalRequest];
+}
+
+- (BOOL)resourceLoader:(AVAssetResourceLoader *)resourceLoader shouldWaitForLoadingOfRequestedResource:(AVAssetResourceLoadingRequest *)loadingRequest {
+    return [self loadingRequestHandling:loadingRequest];;
+}
+
+- (void)resourceLoader:(AVAssetResourceLoader *)resourceLoader
+    didCancelLoadingRequest:(AVAssetResourceLoadingRequest *)loadingRequest {
+  NSLog(@"didCancelLoadingRequest");
+}
+
+- (BOOL)loadingRequestHandling:(AVAssetResourceLoadingRequest *)loadingRequest {
+    NSLog(@"loadingRequestHandling");
+    
+    if(loadingRequest.contentInformationRequest != nil) {
+        // fill up contentInformationRequest end return
+        loadingRequest.contentInformationRequest.contentType = @"public.mp3";
+        loadingRequest.contentInformationRequest.contentLength = _data.length;
+        [loadingRequest.contentInformationRequest setByteRangeAccessSupported:YES];
+        [loadingRequest finishLoading];
+        return YES;
+    }
+    
+    // slice data as requested
+    AVAssetResourceLoadingDataRequest *dataRequest = loadingRequest.dataRequest;
+    
+    long long startOffset = dataRequest.requestedOffset;
+    if (dataRequest.currentOffset != 0){
+        startOffset = dataRequest.currentOffset;
+    }
+    NSUInteger unreadBytes = _data.length - startOffset;
+    NSUInteger numberOfBytesToRespondWith = dataRequest.requestedLength >= unreadBytes ? unreadBytes : dataRequest.requestedLength;
+    NSRange r = {startOffset, numberOfBytesToRespondWith};
+    NSData *data = [_data subdataWithRange:r];
+    
+    // provide sliced data
+    if(data){
+        [dataRequest respondWithData:data];
+        [loadingRequest finishLoading];
+        return YES;
+    }
+
+    NSError *error = [NSError errorWithDomain: @"ReactPlayerItem"
+                                         code: -1
+                                     userInfo: @{NSLocalizedDescriptionKey: @"loadingRequestHandling - error providing data"}
+                      ];
+
+    [loadingRequest finishLoadingWithError:error];
+
+    return NO;
+}
+
+#pragma mark - utilities
+
++ (NSData *)base64DataFromBase64String: (NSString *)base64String {
+  if (base64String != nil) {
+    // NSData from the Base64 encoded str
+    NSData *base64Data = [[NSData alloc] initWithBase64EncodedString:base64String options:NSASCIIStringEncoding];
+    return base64Data;
+  }
+  return nil;
+}
+
 
 @end


### PR DESCRIPTION
# Summary

this PR is for supporting inline base64 audio url in the standard form
`data:<MIMETYPE>;base64,<BASE64_ENCODED>`

So the following should fork:
```js
new Player('data:audio/mp3;base64,UklGRhwMAABXQ...').play();
```

on android it is straight forward since `MediaPlayer` supports this format OOTB.

on IOS `AVPlayer` seems not support it (`AVAudioPlayer` maybe) so I implemented a `AVAssetResourceLoaderDelegate` for `AVAsset` initialized with a dummy url.

**on purpose, haven't I implemented decoding base64 to a temp file before initializing the asset, it's our requirement to remain in memory for higher security. Decode to temp file could be added as an option**

## Test Plan

I tested (only on simulators) on a dirty modified example app. 
![image](https://user-images.githubusercontent.com/15999009/84529792-61b41680-ace2-11ea-8951-67d0c9feea1c.png)

![image](https://user-images.githubusercontent.com/15999009/84531281-a9d43880-ace4-11ea-8cde-512e3717dfcd.png)


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
