### PR TITLE
recorder-metering

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -220,6 +220,11 @@ Player.isPrepared   true if player is prepared
       // Quality of the recording, iOS only.
       // Possible values: 'min', 'low', 'medium', 'high', 'max'
       quality : String (default: 'medium')
+
+      // Optional argument to activate metering events
+      // this will cause 'meter' event to fire everi given milliseconds.
+      // i.e. 250 will fire 4 time in a second.
+      meteringInterval : Number (default: undefined)
     }
     ```
 
@@ -310,6 +315,15 @@ are supported:
 
 * `looped` - Playback of a file has looped.
 
+* `meter` - recurring event during recording session (see `meteringInterval` in `recorderOptions`). `data` associated to this event follows the format:
+    ```js
+    {
+        "id",             // frame number
+        "value",          // sound level in decibels, -160 is a silence level
+        "rawValue"        // raw level value, OS-dependent
+    }
+    ```
+    **Currently, only one recored at a time generates meter events. Last prepared Recorder wins.**
 
 Listen to these events with  `player.on('eventname', callback(data))`.  Data
 may contain additional information about the event, for example a more detailed

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioRecorder.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioRecorder.m
@@ -21,11 +21,19 @@
 
 @end
 
-@implementation AudioRecorder
+@implementation AudioRecorder {
+    id _meteringUpdateTimer;
+    int _meteringFrameId;
+    int _meteringUpdateInterval;
+    NSNumber *_meteringRecorderId;
+    AVAudioRecorder *_meteringRecorder;
+    NSDate *_prevMeteringUpdateTime;
+}
 
 @synthesize bridge = _bridge;
 
 - (void)dealloc {
+    [self stopMeteringTimer];
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     NSError *error = nil;
     [audioSession setActive:NO error:&error];
@@ -45,6 +53,53 @@
 
 -(NSNumber *) keyForRecorder:(nonnull AVAudioRecorder*)recorder {
     return [[_recorderPool allKeysForObject:recorder] firstObject];
+}
+
+#pragma mark - Metering functions
+
+- (void)stopMeteringTimer {
+    [_meteringUpdateTimer invalidate];
+    _meteringFrameId = 0;
+    _prevMeteringUpdateTime = nil;
+    _meteringRecorderId = nil;
+    _meteringRecorder = nil;
+}
+
+- (void)startMeteringTimer:(int)monitorInterval {
+    _meteringUpdateInterval = monitorInterval;
+
+    [self stopMeteringTimer];
+
+    _meteringUpdateTimer = [CADisplayLink displayLinkWithTarget:self selector:@selector(sendMeteringUpdate)];
+    [_meteringUpdateTimer addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+}
+
+- (void)sendMeteringUpdate {
+    if(!_meteringRecorder) {
+        [self stopMeteringTimer];
+        return;
+    }
+    if (!_meteringRecorder.isRecording) {
+        return;
+    }
+
+    if (_prevMeteringUpdateTime == nil ||
+     (([_prevMeteringUpdateTime timeIntervalSinceNow] * -1000.0) >= _meteringUpdateInterval)) {
+        _meteringFrameId++;
+        NSMutableDictionary *body = [[NSMutableDictionary alloc] init];
+        [body setObject:[NSNumber numberWithFloat:_meteringFrameId] forKey:@"id"];
+
+        [_meteringRecorder updateMeters];
+        float _currentLevel = [_meteringRecorder averagePowerForChannel: 0];
+        [body setObject:[NSNumber numberWithFloat:_currentLevel] forKey:@"value"];
+        [body setObject:[NSNumber numberWithFloat:_currentLevel] forKey:@"rawValue"];
+        NSString *eventName = [NSString stringWithFormat:@"RCTAudioRecorderEvent:%@", _meteringRecorderId];
+        [self.bridge.eventDispatcher sendAppEventWithName:eventName
+                                                     body:@{@"event" : @"meter",
+                                                            @"data" : body
+                                                          }];
+        _prevMeteringUpdateTime = [NSDate date];
+    }
 }
 
 #pragma mark - React exposed functions
@@ -127,6 +182,16 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber *)recorderId
         return;
     }
     
+    NSNumber *meteringInterval = [options objectForKey:@"meteringInterval"];
+    if (meteringInterval) {
+        recorder.meteringEnabled = YES;
+        [self startMeteringTimer:[meteringInterval intValue]];
+        if (_meteringRecorderId != nil)
+            NSLog(@"multiple recorder metering are not currently supporter. Metering will be active on the last recorder.");
+        _meteringRecorderId = recorderId;
+        _meteringRecorder = recorder;
+    }
+    
     callback(@[[NSNull null], filePath]);
 }
 
@@ -154,6 +219,9 @@ RCT_EXPORT_METHOD(stop:(nonnull NSNumber *)recorderId withCallback:(RCTResponseS
         NSDictionary* dict = [Helpers errObjWithCode:@"notfound" withMessage:@"Recorder with that id was not found"];
         callback(@[dict]);
         return;
+    }
+    if(recorderId == _meteringRecorderId) {
+        [self stopMeteringTimer];
     }
     callback(@[[NSNull null]]);
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -254,6 +254,13 @@ interface RecorderOptions {
      * (Default: 'medium')
      */
     quality: string;
+
+    /**
+     * Set monitor interval in millisecond.
+     * Passing a value recorder will receive
+     * db level while recording.
+     */
+    meteringInterval: number;
 }
 
 /**


### PR DESCRIPTION
# Summary

This PR activates metering capabilities to `Recorder`.
When initializing a recorder with `meteringInterval` option, Recorder starts emitting 'meter' events.

this is an adaptation of https://github.com/punarinta/react-native-sound-level by @punarinta

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
