### PR TITLE
ios player provide duration on prepare

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -220,7 +220,7 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     // Callback when ready / failed
     if (player.currentItem.status == AVPlayerStatusReadyToPlay) {
         player.automaticallyWaitsToMinimizeStalling = false;
-        callback(@[[NSNull null]]);
+        callback(@[[NSNull null],@{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000)}]);
     } else {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"
                                          withMessage:[NSString stringWithFormat:@"Preparing player failed"]];


### PR DESCRIPTION
# Summary

Player on iOS do not provide duration until getCurrentTime is called.
with this PR, duration is immediately available after prepare.

fixes #27 
