### PR TITLE
AudioAttributes on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/rctaudiotoolkit/AudioPlayerModule.java
@@ -256,14 +256,15 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         //MediaPlayer player = MediaPlayer.create(this.context, uri, null, attributes);
         MediaPlayer player = new MediaPlayer();
 
-        /*
-        AudioAttributes attributes = new AudioAttributes.Builder()
-            .setUsage(AudioAttributes.USAGE_UNKNOWN)
-            .setContentType(AudioAttributes.CONTENT_TYPE_UNKNOWN)
-            .build();
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            AudioAttributes attributes = new Builder()
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .build();
 
-        player.setAudioAttributes(attributes);
-        */
+            player.setAudioAttributes(attributes);
+        }
+
         if (path.startsWith("data:audio/")) {
             // Inline data
              try {


### PR DESCRIPTION
Playing audio stream together with video ([react-native-video](https://github.com/react-native-community/react-native-video)) doesn't seem to work correctly without specifying AudioAttributes on Android 6 and 7 (older versions not tested). When playing video and audio simultaneously, the video's soundtrack or audio stream is interrupted. On Android > 7 the problem is not present.

This PR fixes it by setting Media type of attributes. Maybe it's a temporary solution and the library should allow setting attributes according to users' choice.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ |
| Android |    ✅   |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I mentioned this change in `CHANGELOG.md`
