### PR TITLE
Unknown duration error

### DIFF
--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -233,7 +233,7 @@ RCT_EXPORT_METHOD(prepare:(nonnull NSNumber*)playerId
     // Callback when ready / failed
     if (player.currentItem.status == AVPlayerStatusReadyToPlay) {
         player.automaticallyWaitsToMinimizeStalling = false;
-        callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000)}]);
+        callback(@[[NSNull null], @{@"duration": [player duration]}]);
     } else {
         NSDictionary* dict = [Helpers errObjWithCode:@"preparefail"
                                          withMessage:[NSString stringWithFormat:@"Preparing player failed"]];
@@ -266,21 +266,19 @@ RCT_EXPORT_METHOD(seek:(nonnull NSNumber*)playerId withPos:(nonnull NSNumber*)po
     if (position >= 0) {
         NSLog(@"%@", position);
         if (position == 0) {
-            [player.currentItem
-             seekToTime:kCMTimeZero
-             toleranceBefore:kCMTimeZero // for precise positioning
-             toleranceAfter:kCMTimeZero
-             completionHandler:^(BOOL finished) {
-                 callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000),
-                                             @"position": @(CMTimeGetSeconds(player.currentTime) * 1000)}]);
-             }];
+            [player.currentItem seekToTime:kCMTimeZero
+                           toleranceBefore:kCMTimeZero // for precise positioning
+                            toleranceAfter:kCMTimeZero
+                         completionHandler:^(BOOL finished) {
+                callback(@[[NSNull null], @{@"duration": [player duration],
+                                            @"position": [player position]}]);
+            }];
         } else {
-            [player.currentItem
-             seekToTime:CMTimeMakeWithSeconds([position doubleValue] / 1000, 60000)
-             completionHandler:^(BOOL finished) {
-                 callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000),
-                                             @"position": @(CMTimeGetSeconds(player.currentTime) * 1000)}]);
-             }];
+            [player.currentItem seekToTime:CMTimeMakeWithSeconds([position doubleValue] / 1000, 60000)
+                         completionHandler:^(BOOL finished) {
+                callback(@[[NSNull null], @{@"duration": [player duration],
+                                            @"position": [player position]}]);
+            }];
         }
     }
 }
@@ -298,8 +296,8 @@ RCT_EXPORT_METHOD(play:(nonnull NSNumber*)playerId withCallback:(RCTResponseSend
     [player play];
     player.rate = player.speed;
 
-    callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000),
-                                @"position": @(CMTimeGetSeconds(player.currentTime) * 1000)}]);
+    callback(@[[NSNull null], @{@"duration": [player duration],
+                                @"position": [player position]}]);
 }
 
 RCT_EXPORT_METHOD(set:(nonnull NSNumber*)playerId withOpts:(NSDictionary*)options withCallback:(RCTResponseSenderBlock)callback) {
@@ -354,8 +352,8 @@ RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)playerId withCallback:(RCTResponseSend
         [player.currentItem seekToTime:CMTimeMakeWithSeconds(0.0, 60000)];
     }
     
-    callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000),
-                                @"position": @(CMTimeGetSeconds(player.currentTime) * 1000)}]);
+    callback(@[[NSNull null], @{@"duration": [player duration],
+                                @"position": [player position]}]);
 }
 
 RCT_EXPORT_METHOD(pause:(nonnull NSNumber*)playerId withCallback:(RCTResponseSenderBlock)callback) {
@@ -370,8 +368,8 @@ RCT_EXPORT_METHOD(pause:(nonnull NSNumber*)playerId withCallback:(RCTResponseSen
     
     [player pause];
 
-    callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000),
-                                @"position": @(CMTimeGetSeconds(player.currentTime) * 1000)}]);
+    callback(@[[NSNull null], @{@"duration": [player duration],
+                                @"position": [player position]}]);
 }
 
 RCT_EXPORT_METHOD(resume:(nonnull NSNumber*)playerId withCallback:(RCTResponseSenderBlock)callback) {
@@ -400,8 +398,8 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)playerId withCallback:(RCTRe
         return;
     }
 
-    callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000),
-                                @"position": @(CMTimeGetSeconds(player.currentTime) * 1000)}]);
+    callback(@[[NSNull null], @{@"duration": [player duration],
+                                @"position": [player position]}]);
 }
 
 -(void)itemDidFinishPlaying:(NSNotification *) notification {

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayer.h
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayer.h
@@ -16,4 +16,7 @@
 @property (readwrite) BOOL looping;
 @property (readwrite) float speed;
 
+- (NSNumber *)duration;
+- (NSNumber *)position;
+
 @end

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/ReactPlayer.m
@@ -22,4 +22,28 @@
     return self;
 }
 
+- (NSNumber *)duration {
+    NSNumber *duration = @0;
+    
+    if (self.currentItem != nil && self.currentItem.asset != nil) {
+        if (CMTIME_IS_INDEFINITE(self.currentItem.asset.duration) || CMTIME_IS_INVALID(self.currentItem.asset.duration)) {
+            duration = @(-1);
+        } else {
+            duration = @(CMTimeGetSeconds(self.currentItem.asset.duration) * 1000);
+        }
+    }
+    
+    return duration;
+}
+
+- (NSNumber *)position {
+    if (CMTIME_IS_INDEFINITE(self.currentTime) || CMTIME_IS_INVALID(self.currentTime)) {
+        return @(-1);
+    } else {
+        return @(CMTimeGetSeconds(self.currentTime) * 1000);
+    }
+}
+
+
+
 @end


### PR DESCRIPTION
Fix for error when attempting to playback live audio streams.

A live stream will not return a duration or a current time value. Resolved issue #40 by checking player `duration` or `currentTime` against [`CMTIME_IS_INDEFINITE`](https://developer.apple.com/documentation/coremedia/cmtime_is_indefinite?language=objc) or [`CMTIME_IS_INVALID`](https://developer.apple.com/documentation/coremedia/cmtime_is_invalid?language=objc) respectively and return `-1` if invalid.

Adds methods to `ReactPlayer` for `duration` and `position` that accommodates check of live streams that wouldn't have a known duration or position. If duration and position are unknown/invalid the `-duration` or `-position` method will return `-1`. Implements usage of these methods in `AudioPlayer` allowing playback of live streams without throwing an error on the React side like `RCTJSONStringify() encountered the following error: Invalid number value (NaN)`... as the number now return will be `-1`.

This fix will cause no significant changes in usage of the library. Note again that live stream `duration` and `position` values will be `-1`.